### PR TITLE
Make running tests locally more flexible using an environment file.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,29 @@
+# You'll need to set the following in either your environment or in a .env
+# file in the root of the project
+#
+# The values in this file are purely examples to better help understand what it
+# is you need to add
+#
+# The application configuration is read using the Dotenv component
+# (see https://www.npmjs.com/package/dotenv)
+
+# The environment that the automated tests are running in.
+# Currently one of the following:
+# - development
+# - production
+NODE_ENV = development
+
+# Default digital front end URL.
+APP_URL = http://localhost:8000
+
+# Default platform
+PLATFORM = chrome-desktop-test
+
+# Default browser width
+WIDTH = 1070
+
+# Default browser height
+HEIGHT = 1180
+
+# Default timeout
+TIMEOUT = 240000

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+.env
 node_modules
 package-lock.json
 temp

--- a/config.js
+++ b/config.js
@@ -1,15 +1,25 @@
 const commandLineArgs = require('command-line-args')
+require('dotenv').config()
+
+const {
+  APP_URL = 'http://localhost:8000',
+  NODE_ENV = 'production',
+  PLATFORM = 'chrome-desktop-test',
+  WIDTH = '1070',
+  HEIGHT = '1180',
+  TIMEOUT = '240000'
+} = process.env
 
 const optionDefinitions = [
-  { name: 'appUrl', type: String, defaultValue: 'http://localhost:8000' },
+  { name: 'appUrl', type: String, defaultValue: APP_URL },
   { name: 'appUrlCRM', type: String },
   { name: 'format', type: String },
   { name: 'format-options', type: JSON.parse },
   { name: 'loadChromeNmpExtension', type: Boolean, defaultOption: false },
   { name: 'require', type: String },
-  { name: 'timeout', alias: 't', type: Number, defaultValue: 240000 },
-  { name: 'world-parameters', type: JSON.parse, defaultValue: { platform: 'chrome-desktop-test', width: 1070, height: 1180 } },
-  { name: 'env', type: String, defaultValue: 'production' }
+  { name: 'timeout', alias: 't', type: Number, defaultValue: parseInt(`${TIMEOUT}`) },
+  { name: 'world-parameters', type: JSON.parse, defaultValue: { platform: PLATFORM, width: parseInt(`${WIDTH}`), height: parseInt(`${HEIGHT}`) } },
+  { name: 'env', type: String, defaultValue: NODE_ENV }
 ]
 
 const config = commandLineArgs(optionDefinitions, {partial: true})

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "command-line-args": "^5.0.2",
     "cucumber": "^2.3.1",
     "cucumber-html-reporter": "^4.0.3",
+    "dotenv": "^6.1.0",
     "fs-extra": "^7.0.0",
     "geckodriver": "^1.3.0",
     "iedriver": "^3.9.2",


### PR DESCRIPTION
Please note that if no .env file or environment files are set, the tests will run with the default values as before.