### PR TITLE
Removing MCP smoke testing tag

### DIFF
--- a/features/e2e_bespoke_mcp_smoke_test.feature
+++ b/features/e2e_bespoke_mcp_smoke_test.feature
@@ -109,7 +109,6 @@ Feature: Bespoke MCP end to end Smoke test
       | Individual                          | Medium combustion plant or specified generator | Mobile MCP             | skip              | skip          | skip                | no                     | skip               | skip       | skip                | skip                | skip            | skip                      | skip                | skip                         | skip                                    | upload             | skip                | skip    | skip     | BACS    |
       | Public body                         | Medium combustion plant or specified generator | Mobile MCP             | skip              | skip          | skip                | yes                    | skip               | skip       | skip                | skip                | skip            | skip                      | skip                | upload                       | skip                                    | upload             | skip                | skip    | skip     | CARD    |
 
-  @Smoke_prod
   Scenario Outline: As a user I should be able to apply for a bespoke MCP (<MCPType>) permit when the permit holder is a <PermitHolder>
     Given the application has been launched
     And I start a new application


### PR DESCRIPTION
Bespoke MCP permits are being removed from online application process